### PR TITLE
Feature/red black tree

### DIFF
--- a/modules/datastructures/Tree/Node-based/red_black_tree.cppm
+++ b/modules/datastructures/Tree/Node-based/red_black_tree.cppm
@@ -1326,7 +1326,7 @@ namespace j {
             fix = node->_right;
             _transplant(node, node->_right);
             if (node == _nil->_left) {
-                _nil->_left = fix;
+                _nil->_left = fix != _nil ? fix : node->_parent;
             }
         } else if (node->_right == _nil) {
             fix = node->_left;
@@ -1353,6 +1353,7 @@ namespace j {
         if (erased_original_color == color::BLACK) {
             _erase_fix(fix);
         }
+        _size--;
         return node;
     }
 

--- a/modules/datastructures/Tree/Node-based/red_black_tree.cppm
+++ b/modules/datastructures/Tree/Node-based/red_black_tree.cppm
@@ -127,11 +127,11 @@ namespace j {
         iterator emplace_hint(const_iterator hint, Args &&... args);
         iterator insert(const value_type &x);
         iterator insert(value_type &&x);
-        template <class K> requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, value_type>
         iterator insert(K &&x);
         iterator insert(const_iterator hint, const value_type &x);
         iterator insert(const_iterator hint, value_type &&x);
-        template <class K> requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, value_type>
         iterator insert(const_iterator hint, K &&x);
         template <class InputIter>
         requires (!std::is_integral_v<InputIter>)
@@ -146,11 +146,11 @@ namespace j {
         iterator emplace_hint_unique(const_iterator hint, Args &&... args);
         std::pair<iterator, bool> insert_unique(const value_type &x);
         std::pair<iterator, bool> insert_unique(value_type &&x);
-        template <class K> requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, value_type>
         std::pair<iterator, bool> insert_unique(K &&x);
         iterator insert_unique(const_iterator hint, const value_type &x);
         iterator insert_unique(const_iterator hint, value_type &&x);
-        template <class K> requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, value_type>
         iterator insert_unique(const_iterator hint, K &&x);
         template <class InputIter>
         requires (!std::is_integral_v<InputIter>)
@@ -161,7 +161,7 @@ namespace j {
 
         node_type extract(const_iterator position);
         node_type extract(const key_type &x);
-        template <class K> requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         node_type extract(K &&x);
         insert_return_type insert(node_type &&node);
         insert_return_type insert(const_iterator position, node_type &&node);
@@ -172,7 +172,7 @@ namespace j {
             requires (!std::is_same_v<iterator, const_iterator>);
         iterator erase(const_iterator position);
         size_type erase(const key_type &x);
-        template <class K> requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         size_type erase(K &&x);
         iterator erase(const_iterator first, const_iterator last);
         void swap(red_black_tree &x) noexcept(
@@ -197,48 +197,38 @@ namespace j {
         // Operations
         iterator find(const key_type &x);
         const_iterator find(const key_type &x) const;
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         iterator find(const K &x);
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         const_iterator find(const K &x) const;
 
         size_type count(const key_type &x) const;
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         size_type count(const K &x) const;
 
         bool contains(const key_type &x) const;
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         bool contains(const K &x) const;
 
         iterator lower_bound(const key_type &x);
         const_iterator lower_bound(const key_type &x) const;
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         iterator lower_bound(const K &x);
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         const_iterator lower_bound(const K &x) const;
 
         iterator upper_bound(const key_type &x);
         const_iterator upper_bound(const key_type &x) const;
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         iterator upper_bound(const K &x);
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         const_iterator upper_bound(const K &x) const;
 
         std::pair<iterator, iterator> equal_range(const key_type &x);
         std::pair<const_iterator, const_iterator> equal_range(const key_type &x) const;
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         std::pair<iterator, iterator> equal_range(const K &x);
-        template <class K>
-        requires std::convertible_to<K, Key>
+        template <class K> requires std::convertible_to<K, key_type>
         std::pair<const_iterator, const_iterator> equal_range(const K &x) const;
     };
 
@@ -276,7 +266,7 @@ namespace j {
         explicit value_compare(Compare c) : _comp(c) {}
 
         bool operator()(Key const &lhs, Key const& rhs) const {
-            if constexpr (is_std_pair_v<Key>) {
+            if constexpr (_is_std_pair_v<Key>) {
                 return _comp(lhs.first, rhs.first);
             } else {
                 return _comp(lhs, rhs);
@@ -292,7 +282,7 @@ namespace j {
 
     protected:
         using node = _red_black_tree_node;
-        key_type _key;
+        value_type _value;
         color _color;
         node *_left;
         node *_right;
@@ -300,15 +290,16 @@ namespace j {
 
     public:
         _red_black_tree_node() : _red_black_tree_node(color::RED, nullptr) {}
-        _red_black_tree_node(color color, node* node) : _red_black_tree_node(key_type(), color, node) {}
-        _red_black_tree_node(const key_type &key, color color, node* node)
-            : _key(key), _color(color), _left(node), _right(node), _parent(node) {}
-        _red_black_tree_node(key_type &&key, color color, node* node)
-            : _key(std::move(key)), _color(color), _left(node), _right(node), _parent(node) {}
-        key_type& operator*() { return _key; }
-        const key_type& operator*() const { return _key; }
+        _red_black_tree_node(color color, node* node) : _red_black_tree_node(value_type(), color, node) {}
+        _red_black_tree_node(const value_type &value, color color, node* node)
+            : _value(value), _color(color), _left(node), _right(node), _parent(node) {}
+        _red_black_tree_node(value_type &&value, color color, node* node)
+            : _value(std::move(value)), _color(color), _left(node), _right(node), _parent(node) {}
+        key_type& key() { return key_extractor(_value); }
+        const key_type& key() const { return key_extractor(_value); }
+        value_type& operator*() { return _value; }
+        const value_type& operator*() const { return _value; }
         ~_red_black_tree_node() {
-            _key.~key_type();
             _left = nullptr;
             _right = nullptr;
             _parent = nullptr;
@@ -353,19 +344,11 @@ namespace j {
         void swap(node_type &other) noexcept { std::swap(_ptr, other._ptr); }
         const auto& key() const {
             if (empty()) throw std::runtime_error("node_type is empty");
-            if constexpr (is_std_pair_v<Key>) {
-                return _ptr->_key.first;
-            } else {
-                return _ptr->_key;
-            }
+            return _ptr->key();
         }
         const auto& value() const {
             if (empty()) throw std::runtime_error("node_type is empty");
-            if constexpr (is_std_pair_v<Key>) {
-                return _ptr->_key.second;
-            } else {
-                static_assert(sizeof(Key) == 0, "value() is not available for non-pair key_type");
-            }
+            return _ptr->_value;
         }
     };
 
@@ -471,8 +454,8 @@ namespace j {
     red_black_tree(InputIter first, InputIter last, const Compare& comp, const Allocator& alloc)
         : _comp(comp), _alloc(alloc) {
         _nil = std::allocator_traits<node_allocator_type>::allocate(_alloc, 1);
-        _root = _nil;
         std::construct_at(_nil, color::BLACK, _nil);
+        _root = _nil;
         insert(first, last);
     }
 
@@ -838,7 +821,7 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-        template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     typename red_black_tree<Key, Compare, Allocator>::node_type
     red_black_tree<Key, Compare, Allocator>::extract(K&& x) {
         return extract(find(std::forward<K>(x)));
@@ -851,7 +834,7 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    typename red_black_tree<Key, Compare, Allocator>::insert_return_type
+    typename red_black_tree<Key, Compare, Allocator>::iterator
     red_black_tree<Key, Compare, Allocator>::insert(const_iterator position, node_type&& node) {
         auto find_pos = _find_insert_position(position, node.key());
         auto parent = find_pos.first._ptr;
@@ -869,7 +852,7 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    typename red_black_tree<Key, Compare, Allocator>::insert_return_type
+    typename red_black_tree<Key, Compare, Allocator>::iterator
     red_black_tree<Key, Compare, Allocator>::insert_unique(const_iterator position, node_type&& node) {
         auto find_pos = _find_insert_position(position, node.key());
         auto parent = find_pos.first._ptr;
@@ -913,7 +896,7 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     typename red_black_tree<Key, Compare, Allocator>::size_type red_black_tree<Key, Compare, Allocator>::erase(K&& x) {
         const size_type old_size = _size;
         erase(lower_bound(std::forward<K>(x)), upper_bound(std::forward<K>(x)));
@@ -945,7 +928,7 @@ namespace j {
     void red_black_tree<Key, Compare, Allocator>::unique() {
         if (empty()) return;
         for (auto it = std::next(begin()), temp = begin(); it != end();) {
-            if (*it == *temp) {
+            if (key_extractor(*it) == key_extractor(*temp)) {
                 it = erase(it);
             } else {
                 temp = it++;
@@ -1005,10 +988,10 @@ namespace j {
     red_black_tree<Key, Compare, Allocator>::find(const key_type& x) {
         Node *finder = _root;
         while (finder != _nil) {
-            if (finder->_key == x) {
+            if (finder->key() == x) {
                 return iterator(finder, this);
             }
-            if (_comp(finder->_key, x)) {
+            if (_comp(finder->key(), x)) {
                 finder = finder->_right;
             } else {
                 finder = finder->_left;
@@ -1024,14 +1007,14 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     typename red_black_tree<Key, Compare, Allocator>::iterator
     red_black_tree<Key, Compare, Allocator>::find(const K& x) {
         return find(static_cast<const key_type&>(x));
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     typename red_black_tree<Key, Compare, Allocator>::const_iterator
     red_black_tree<Key, Compare, Allocator>::find(const K& x) const {
         return find(static_cast<const key_type&>(x));
@@ -1044,7 +1027,7 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     typename red_black_tree<Key, Compare, Allocator>::size_type
     red_black_tree<Key, Compare, Allocator>::count(const K& x) const {
         return count(static_cast<const key_type&>(x));
@@ -1056,7 +1039,7 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     bool red_black_tree<Key, Compare, Allocator>::contains(const K& x) const {
         return contains(static_cast<const key_type&>(x));
     }
@@ -1067,7 +1050,7 @@ namespace j {
         Node *lower = _root;
         Node *result = _nil;
         while (lower && lower != _nil) {
-            if (!_comp(lower->_key, x)) {
+            if (!_comp(lower->key(), x)) {
                 result = lower;
                 lower = lower->_left;
             } else {
@@ -1084,14 +1067,14 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     typename red_black_tree<Key, Compare, Allocator>::iterator
     red_black_tree<Key, Compare, Allocator>::lower_bound(const K& x) {
         return lower_bound(static_cast<const key_type&>(x));
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     typename red_black_tree<Key, Compare, Allocator>::const_iterator
     red_black_tree<Key, Compare, Allocator>::lower_bound(const K& x) const {
         return const_iterator(lower_bound(static_cast<const key_type&>(x)));
@@ -1103,7 +1086,7 @@ namespace j {
         Node *upper = _root;
         Node *result = _nil;
         while (upper && upper != _nil) {
-            if (_comp(x, upper->_key)) {
+            if (_comp(x, upper->key())) {
                 result = upper;
                 upper = upper->_left;
             } else {
@@ -1120,14 +1103,14 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     typename red_black_tree<Key, Compare, Allocator>::iterator
     red_black_tree<Key, Compare, Allocator>::upper_bound(const K& x) {
         return upper_bound(static_cast<const key_type&>(x));
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     typename red_black_tree<Key, Compare, Allocator>::const_iterator
     red_black_tree<Key, Compare, Allocator>::upper_bound(const K& x) const {
         return const_iterator(upper_bound(static_cast<const key_type&>(x)));
@@ -1148,7 +1131,7 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     std::pair<typename red_black_tree<Key, Compare, Allocator>::iterator,
               typename red_black_tree<Key, Compare, Allocator>::iterator>
     red_black_tree<Key, Compare, Allocator>::equal_range(const K& x) {
@@ -1157,7 +1140,7 @@ namespace j {
     }
 
     template <class Key, class Compare, class Allocator>
-    template <class K> requires std::convertible_to<K, Key>
+    template <class K> requires std::convertible_to<K, typename _key_mapper<Key>::key_type>
     std::pair<typename red_black_tree<Key, Compare, Allocator>::const_iterator,
               typename red_black_tree<Key, Compare, Allocator>::const_iterator>
     red_black_tree<Key, Compare, Allocator>::equal_range(const K& x) const {
@@ -1215,30 +1198,25 @@ namespace j {
         if (_size == 0) {
             return std::make_pair(end(), true);
         }
-        if ((hint == end() || _comp(x, *hint)) && (hint == begin() || _comp(*std::prev(hint), x))) {
-            return std::make_pair(hint, true);
-        }
         Node *finder = _root;
-        if (finder == _nil) {
-            return std::make_pair(const_iterator(finder, this), true);
+        if ((hint == end() || _comp(x, key_extractor(*hint))) &&
+           (hint == begin() || _comp(key_extractor(*std::prev(hint)), x))) {
+            finder = hint._ptr;
         }
         bool unique = true;
-        while (true) {
-            if (finder->_key == x) {
+        while (finder != _nil) {
+            if (finder->key() == x) {
                 unique = false;
             }
-            if (_comp(finder->_key, x)) {
-                if (finder->_right == _nil) {
-                    return std::make_pair(const_iterator(finder, this), unique);
-                }
+            if (_comp(finder->key(), x)) {
+                if (finder->_right == _nil) break;
                 finder = finder->_right;
             } else {
-                if (finder->_left == _nil) {
-                    return std::make_pair(const_iterator(finder, this), unique);
-                }
+                if (finder->_left == _nil) break;
                 finder = finder->_left;
             }
         }
+        return std::make_pair(iterator(finder, this), unique);
     } // return leaf position
 
     template <class Key, class Compare, class Allocator>
@@ -1251,7 +1229,7 @@ namespace j {
             _nil->_right = new_node;
             return;
         } // empty tree
-        if (_comp(node->_key, new_node->_key)) {
+        if (_comp(node->key(), new_node->key())) {
             node->_right = new_node;
             if (node == _nil->_right) {
                 _nil->_right = new_node;
@@ -1281,14 +1259,14 @@ namespace j {
                 uncle->_color = color::BLACK;
                 node = grandparent;
             } else {
-                if (_comp(parent->_key, grandparent->_key)) {
-                    if (_comp(parent->_key, node->_key)) {
+                if (_comp(parent->key(), grandparent->key())) {
+                    if (_comp(parent->key(), node->key())) {
                         _left_rotate(parent);
                         node = parent;
                     }
                     _right_rotate(grandparent);
                 } else {
-                    if (_comp(node->_key, parent->_key)) {
+                    if (_comp(node->key(), parent->key())) {
                         _right_rotate(parent);
                         node = parent;
                     }

--- a/modules/datastructures/basics.cppm
+++ b/modules/datastructures/basics.cppm
@@ -17,18 +17,6 @@ namespace j
     export template <class T, class Alloc>
     struct uses_allocator : std::false_type {};
 
-    template <typename T>
-    struct is_std_pair : std::false_type { };
-
-    template <typename T, typename U>
-    struct is_std_pair<std::pair<T, U>> : std::true_type { };
-
-    template <typename T>
-    inline constexpr bool is_std_pair_v = is_std_pair<T>::value;
-
-    export template <typename T>
-    concept IsPair = is_std_pair_v<T>;
-
     // Operation (Monoid)
     export template <class T>
     struct plus

--- a/modules/helper/tree_helper.cppm
+++ b/modules/helper/tree_helper.cppm
@@ -1,0 +1,67 @@
+/*
+ * @ Created by jaehyung409 on 25. 2. 22.
+ * @ Copyright (c) 2025 jaehyung409 All rights reserved.
+ * This software is licensed under the MIT License. 
+ */
+
+module;
+#include <functional>
+
+export module j.tree_helper;
+
+namespace j {
+    template <class T>
+    struct is_std_pair : std::false_type {};
+
+    template <class K, class V>
+    struct is_std_pair<std::pair<K, V>> : std::true_type {};
+
+    export template <class T>
+    constexpr bool is_std_pair_v = is_std_pair<T>::value;
+
+    export template <class T, bool = is_std_pair_v<T>>
+    struct key_mapper;
+
+    template <class T>
+    struct key_mapper<T, false> {
+        using key_type = T;
+        using mapped_type = T;
+    };
+
+    template <class T>
+    struct key_mapper<T, true> {
+        using key_type = typename T::first_type;
+        using mapped_type = typename T::second_type;
+    };
+
+    template <class T, bool IsConst, bool = is_std_pair_v<T>>
+    struct reference_selector_impl;
+
+    template <class T, bool IsConst>
+    struct reference_selector_impl<T, IsConst, false> {
+        using type = std::conditional_t<IsConst, const T&, T&>;
+    };
+
+    template <class T, bool IsConst>
+    struct reference_selector_impl<T, IsConst, true> {
+    private:
+        using K = typename T::first_type;
+        using V = typename T::second_type;
+    public:
+        using type = std::pair<const K, std::conditional_t<IsConst, const V, V>>&;
+    };
+
+    export template <class T, bool IsConst>
+    using reference_selector = typename reference_selector_impl<T, IsConst>::type;
+
+    export template <class Key>
+    struct default_compare {
+        bool operator()(Key const &lhs, Key const& rhs) const {
+            if constexpr (is_std_pair_v<Key>) {
+                return lhs.first < rhs.first;
+            } else {
+                return lhs < rhs;
+            }
+        }
+    };
+}

--- a/modules/helper/tree_helper.cppm
+++ b/modules/helper/tree_helper.cppm
@@ -11,39 +11,50 @@ export module j.tree_helper;
 
 namespace j {
     template <class T>
-    struct is_std_pair : std::false_type {};
+    struct _is_std_pair : std::false_type {};
 
     template <class K, class V>
-    struct is_std_pair<std::pair<K, V>> : std::true_type {};
+    struct _is_std_pair<std::pair<K, V>> : std::true_type {};
 
     export template <class T>
-    constexpr bool is_std_pair_v = is_std_pair<T>::value;
+    constexpr bool _is_std_pair_v = _is_std_pair<T>::value;
 
-    export template <class T, bool = is_std_pair_v<T>>
-    struct key_mapper;
+    export template <class T, bool = _is_std_pair_v<T>>
+    struct _key_mapper;
 
     template <class T>
-    struct key_mapper<T, false> {
+    struct _key_mapper<T, false> {
         using key_type = T;
         using mapped_type = T;
     };
 
     template <class T>
-    struct key_mapper<T, true> {
+    struct _key_mapper<T, true> {
         using key_type = typename T::first_type;
         using mapped_type = typename T::second_type;
     };
 
-    template <class T, bool IsConst, bool = is_std_pair_v<T>>
-    struct reference_selector_impl;
+    export template <class T>
+    struct _key_extractor {
+        constexpr auto extract(const T& value) {
+            if constexpr (_is_std_pair_v<T>) {
+                return value.first;
+            } else {
+                return value;
+            }
+        }
+    };
+
+    template <class T, bool IsConst, bool = _is_std_pair_v<T>>
+    struct _reference_selector_impl;
 
     template <class T, bool IsConst>
-    struct reference_selector_impl<T, IsConst, false> {
+    struct _reference_selector_impl<T, IsConst, false> {
         using type = std::conditional_t<IsConst, const T&, T&>;
     };
 
     template <class T, bool IsConst>
-    struct reference_selector_impl<T, IsConst, true> {
+    struct _reference_selector_impl<T, IsConst, true> {
     private:
         using K = typename T::first_type;
         using V = typename T::second_type;
@@ -52,12 +63,12 @@ namespace j {
     };
 
     export template <class T, bool IsConst>
-    using reference_selector = typename reference_selector_impl<T, IsConst>::type;
+    using _reference_selector = typename _reference_selector_impl<T, IsConst>::type;
 
     export template <class Key>
-    struct default_compare {
+    struct _default_compare {
         bool operator()(Key const &lhs, Key const& rhs) const {
-            if constexpr (is_std_pair_v<Key>) {
+            if constexpr (_is_std_pair_v<Key>) {
                 return lhs.first < rhs.first;
             } else {
                 return lhs < rhs;


### PR DESCRIPTION
Previously, my tree structures lacked adequate support for `std::pair`, preventing effective adaptation for map implementations. To address this, we've enhanced the handling of `key`, `value`, and `mapped` types, enabling proper functionality for both `pair` and `non-pair` data types through template metaprogramming.

Additionally, I've synchronized the `_nil` usage and specific function naming conventions in the `avl_tree` with those in the `red-black_tree`, enhancing code consistency and readability. 